### PR TITLE
Conv. layer strides weren't computed correctly dimension wise.

### DIFF
--- a/layer.py
+++ b/layer.py
@@ -543,12 +543,12 @@ class ConvLayer(Layer):
 
             # Make strides and dilation lists
             strides, dilation = [1, 1, 1, 1], [1, 1, 1, 1]
+            if conv_filter_dims[0] > 1:
+                strides[0] = self.shift_spacing
+                dilation[0] = self.dilation
             if conv_filter_dims[1] > 1:
                 strides[1] = self.shift_spacing
                 dilation[1] = self.dilation
-            if conv_filter_dims[2] > 1:
-                strides[2] = self.shift_spacing
-                strides[2] = self.dilation
 
             _pre = tf.nn.conv2d(shaped_input, ws_conv, strides=strides, dilations=dilation, padding='SAME')
             pre = tf.add(_pre, self.biases_var)

--- a/layer.py
+++ b/layer.py
@@ -482,9 +482,9 @@ class ConvLayer(Layer):
         # Calculate number of shifts (for output)
         num_shifts = [1, 1]
         if input_dims[1] > 1:
-            num_shifts[0] = int(np.floor(input_dims[1]/shift_spacing))
+            num_shifts[0] = int(np.ceil(input_dims[1]/shift_spacing))
         if input_dims[2] > 1:
-            num_shifts[1] = int(np.floor(input_dims[2]/shift_spacing))
+            num_shifts[1] = int(np.ceil(input_dims[2]/shift_spacing))
 
         super(ConvLayer, self).__init__(
                 scope=scope,
@@ -542,7 +542,7 @@ class ConvLayer(Layer):
             ws_conv = tf.reshape(w_pn, conv_filter_dims)
 
             # Make strides and dilation lists
-            strides, dilation = [1, 1, 1, 1], [1, 1, 1, 1]
+            strides, dilation = [1, 1], [1, 1]
             if conv_filter_dims[0] > 1:
                 strides[0] = self.shift_spacing
                 dilation[0] = self.dilation


### PR DESCRIPTION
Convolutional layer strides were computed for 2nd (filter_width) and 3rd (in_channels) dimension instead of 1st (filter_height) and 2nd (filter_width). The error was only in build_graph, the computation of sizes was correct. 

This issue lead to error on runtime due to incorrect tensor sizes for reshapes in conv layer.