### PR TITLE
Revert "Conv. layer strides weren't computed correctly dimension wise."

### DIFF
--- a/layer.py
+++ b/layer.py
@@ -482,9 +482,9 @@ class ConvLayer(Layer):
         # Calculate number of shifts (for output)
         num_shifts = [1, 1]
         if input_dims[1] > 1:
-            num_shifts[0] = int(np.ceil(input_dims[1]/shift_spacing))
+            num_shifts[0] = int(np.floor(input_dims[1]/shift_spacing))
         if input_dims[2] > 1:
-            num_shifts[1] = int(np.ceil(input_dims[2]/shift_spacing))
+            num_shifts[1] = int(np.floor(input_dims[2]/shift_spacing))
 
         super(ConvLayer, self).__init__(
                 scope=scope,
@@ -542,13 +542,13 @@ class ConvLayer(Layer):
             ws_conv = tf.reshape(w_pn, conv_filter_dims)
 
             # Make strides and dilation lists
-            strides, dilation = [1, 1], [1, 1]
-            if conv_filter_dims[0] > 1:
-                strides[0] = self.shift_spacing
-                dilation[0] = self.dilation
+            strides, dilation = [1, 1, 1, 1], [1, 1, 1, 1]
             if conv_filter_dims[1] > 1:
                 strides[1] = self.shift_spacing
                 dilation[1] = self.dilation
+            if conv_filter_dims[2] > 1:
+                strides[2] = self.shift_spacing
+                strides[2] = self.dilation
 
             _pre = tf.nn.conv2d(shaped_input, ws_conv, strides=strides, dilations=dilation, padding='SAME')
             pre = tf.add(_pre, self.biases_var)


### PR DESCRIPTION
Reverts NeuroTheoryUMD/NDN3#11
-- This actually seems to introduce bugs in the code. For whatever reason, (from conv2d) it appears that the strides should be a 4-d vector with [1] and [2] corresponding to horizontal and vertical strides. 