### PR TITLE
Introduce the ability to compute pearson correlation as part of summaries

### DIFF
--- a/NDN.py
+++ b/NDN.py
@@ -455,14 +455,14 @@ class NDN(object):
             x_mean = tf.reduce_mean(x, axis=0)
             y_mean = tf.reduce_mean(y, axis=0)
             corr_per_neuron = tf.divide(
-                    ((x-x_mean)*(y-y_mean))
+                    tf.reduce_sum((x-x_mean)*(y-y_mean), axis=0)
                 ,
                     tf.sqrt(tf.reduce_sum((x - x_mean)**2, axis=0))*
                     tf.sqrt(tf.reduce_sum((y - y_mean)**2,axis=0))
                 )
-            corr_no_nans = tf.where(tf.is_nan(corr_per_neuron), tf.zeros_like(corr_per_neuron), corr_per_neuron)
+            corr_no_nans = tf.where(tf.is_finite(corr_per_neuron), corr_per_neuron, tf.zeros_like(corr_per_neuron))
 
-            self.correlation = tf.reduce_sum(corr_no_nans, axis=0)
+            self.correlation = corr_no_nans
             tf.summary.scalar('correlation', tf.reduce_mean(self.correlation))
 
 

--- a/NDN.py
+++ b/NDN.py
@@ -1064,6 +1064,7 @@ class NDN(object):
         target.data_pipe_type = self.data_pipe_type
         target.batch_size = self.batch_size
         target.time_spread = self.time_spread
+        target.log_correlation = self.log_correlation
 
         # Copy all the parameters
         for nn in range(self.num_networks):

--- a/NDN.py
+++ b/NDN.py
@@ -449,6 +449,23 @@ class NDN(object):
             else:
                 TypeError('Cost function not supported.')
 
+        with tf.name_scope('correlation'):
+            x = pred
+            y = data_out
+            x_mean = tf.reduce_mean(x, axis=0)
+            y_mean = tf.reduce_mean(y, axis=0)
+            corr_per_neuron = tf.divide(
+                    ((x-x_mean)*(y-y_mean))
+                ,
+                    tf.sqrt(tf.reduce_sum((x - x_mean)**2, axis=0))*
+                    tf.sqrt(tf.reduce_sum((y - y_mean)**2,axis=0))
+                )
+            corr_no_nans = tf.where(tf.is_nan(corr_per_neuron), tf.zeros_like(corr_per_neuron), corr_per_neuron)
+
+            self.correlation = tf.reduce_sum(corr_no_nans, axis=0)
+            tf.summary.scalar('correlation', tf.reduce_mean(self.correlation))
+
+
         self.cost = tf.add_n(cost)
         self.unit_cost = unit_cost # this is not yet normalized
 

--- a/NDN.py
+++ b/NDN.py
@@ -36,7 +36,7 @@ class NDN(object):
             stream
         noise_dist (str): specifies the probability distribution used to define
             the cost function
-            ['poisson'] | 'gaussian' | 'bernoulli'
+            ['poisson' | 'gaussian' | 'bernoulli']
         tf_seed (int): rng seed for both tensorflow and numpy, which allows
             for reproducibly random initializations of parameters
         cost
@@ -49,6 +49,11 @@ class NDN(object):
         init (tf.global_variables_initializer op): for initializing variables
         sess_config (tf.ConfigProto object): specifies configurations for
             tensorflow session, such as GPU utilization
+        log_correlation (str): log correlation 
+            ['zero-NaNs' | 'filter-NaNs' | 'filter-low-std-gold']. 
+            'zero-NaNs': Assumes 0 correlation for neurons with NaN correlation.
+            'filter-NaNs': Ignores neurons with NaN correlation.
+            'filter-low-std-gold': 'filter-NaNs' + ignores neurons for which golden data have small std (<1e-5), based on https://openreview.net/pdf?id=H1fU8iAqKX | https://github.com/aecker/cnn-sys-ident/blob/master/cnn_sys_ident/architectures/training.py#L84
 
     Notes:
         One assumption is that the output of all FFnetworks -- whether or not
@@ -162,6 +167,9 @@ class NDN(object):
         self.saver = None
         self.merge_summaries = None
         self.init = None
+
+        # set log parameters
+        self.log_correlation = None
     # END NDN.__init__
 
     def _define_network(self):
@@ -376,6 +384,7 @@ class NDN(object):
         cost = []
         self.cost_iter = [] ###
         unit_cost = []
+        unit_corr = []
         for nn in range(len(self.ffnet_out)):
             if self.time_spread is None:
                 time_spread = 0
@@ -389,8 +398,10 @@ class NDN(object):
                 pred_tmp = tf.multiply(
                     self.networks[self.ffnet_out[nn]].layers[-1].outputs,
                     self.data_filter_batch[nn])
+                data_filter_batch = self.data_filter_batch[nn]
             else:
                 pred_tmp = self.networks[self.ffnet_out[nn]].layers[-1].outputs
+                data_filter_batch = tf.ones_like(pred_tmp)
 
             #pred = pred_tmp[time_spread:, :]
 
@@ -449,21 +460,55 @@ class NDN(object):
             else:
                 TypeError('Cost function not supported.')
 
-        with tf.name_scope('correlation'):
-            x = pred
-            y = data_out
-            x_mean = tf.reduce_mean(x, axis=0)
-            y_mean = tf.reduce_mean(y, axis=0)
-            corr_per_neuron = tf.divide(
-                    tf.reduce_sum((x-x_mean)*(y-y_mean), axis=0)
-                ,
-                    tf.sqrt(tf.reduce_sum((x - x_mean)**2, axis=0))*
-                    tf.sqrt(tf.reduce_sum((y - y_mean)**2,axis=0))
-                )
-            corr_no_nans = tf.where(tf.is_finite(corr_per_neuron), corr_per_neuron, tf.zeros_like(corr_per_neuron))
+            if self.log_correlation:
+                with tf.name_scope('correlation_comp'):
 
-            self.correlation = corr_no_nans
-            tf.summary.scalar('correlation', tf.reduce_mean(self.correlation))
+                    filter_low_std = self.log_correlation == 'filter-low-std-gold'
+                    # If we want filter out low-std on gold, we (for sure) want to filter out NaNs as well
+                    filter_NaNs = self.log_correlation == 'filter-low-std-gold' or self.log_correlation == 'filter-NaNs'
+
+                    x = pred
+                    y = data_out
+                    y.set_shape(x.shape)
+
+                    non_filtered_count = tf.reduce_sum(data_filter_batch, axis=0)
+
+                    x_mean = tf.divide(tf.reduce_sum(x, axis=0), non_filtered_count)
+                    y_mean = tf.divide(tf.reduce_sum(y, axis=0), non_filtered_count)
+                    y_std = tf.math.reduce_std(y, axis=0)
+
+                    # Filter out data-points that correspond to data_filters -> 0 diff from mean -> 0 contr. to corr
+                    x_mean_d = tf.where(data_filter_batch > 0, (x-x_mean), tf.zeros_like(x))
+                    y_mean_d = tf.where(data_filter_batch > 0, (y-y_mean), tf.zeros_like(y))
+
+                    # Compute correlation
+                    corr_per_neuron = tf.divide(
+                            tf.reduce_sum(tf.multiply(x_mean_d, y_mean_d), axis=0)
+                        ,
+                            tf.sqrt(tf.reduce_sum(x_mean_d**2, axis=0))*
+                            tf.sqrt(tf.reduce_sum(y_mean_d**2, axis=0))
+                        )
+                    corr_per_neuron.set_shape([None]) # Fixes TF complaining about mask shapes
+
+                    if filter_low_std:
+                        corr_per_neuron = tf.boolean_mask(corr_per_neuron,tf.greater(y_std, 1e-5))
+
+                    # Either filter out NaN neurons or replace them with 0 so that mean summary can be computed
+                    if filter_NaNs:
+                        corr_no_nans = tf.boolean_mask(corr_per_neuron, tf.is_finite(corr_per_neuron))
+                    else:
+                        corr_no_nans = tf.where(tf.is_finite(corr_per_neuron), corr_per_neuron, tf.zeros_like(corr_per_neuron))
+
+                    unit_corr.append(corr_no_nans)
+
+        if self.log_correlation:
+            with tf.name_scope('correlation'): # https://stackoverflow.com/questions/45670224/why-the-tf-name-scope-with-same-name-is-different
+                self.correlation = tf.divide(tf.add_n(unit_corr), len(unit_corr))
+
+                tf.summary.scalar('correlation', tf.reduce_mean(self.correlation))
+                # Something was actually filtered out -> log number of non-filtered out neurons
+                if self.log_correlation == 'filter-low-std-gold' or self.log_correlation == 'filter-NaNs':
+                    tf.summary.scalar('correlation-non-filtered-out-neurons', tf.shape(self.correlation)[0])
 
 
         self.cost = tf.add_n(cost)

--- a/NDN.py
+++ b/NDN.py
@@ -36,7 +36,7 @@ class NDN(object):
             stream
         noise_dist (str): specifies the probability distribution used to define
             the cost function
-            ['poisson' | 'gaussian' | 'bernoulli']
+            ['poisson'] | 'gaussian' | 'bernoulli'
         tf_seed (int): rng seed for both tensorflow and numpy, which allows
             for reproducibly random initializations of parameters
         cost
@@ -50,7 +50,7 @@ class NDN(object):
         sess_config (tf.ConfigProto object): specifies configurations for
             tensorflow session, such as GPU utilization
         log_correlation (str): log correlation 
-            ['zero-NaNs' | 'filter-NaNs' | 'filter-low-std-gold']. 
+            [ None ] | 'zero-NaNs' | 'filter-NaNs' | 'filter-low-std-gold'. 
             'zero-NaNs': Assumes 0 correlation for neurons with NaN correlation.
             'filter-NaNs': Ignores neurons with NaN correlation.
             'filter-low-std-gold': 'filter-NaNs' + ignores neurons for which golden data have small std (<1e-5), based on https://openreview.net/pdf?id=H1fU8iAqKX | https://github.com/aecker/cnn-sys-ident/blob/master/cnn_sys_ident/architectures/training.py#L84


### PR DESCRIPTION
Computes pearson correlation as part of training summaries the same way all other summaries are computed.
Off by default. Currently the only way to enable it is to set `<ndnObject>.log_correlation` which is not the best way but seemed as the simplest (happy to change that and surface it as a parameter somehow) and definitely a side-effect free one.