### PR TITLE
Propagate tf.seed when saving a model.

### DIFF
--- a/NDN.py
+++ b/NDN.py
@@ -2416,7 +2416,7 @@ class NDN(object):
         import sys
         import dill
 
-        tmp_ndn = self.copy_model()
+        tmp_ndn = self.copy_model(self.tf_seed)
         sys.setrecursionlimit(10000)  # for dill calls to pickle
 
         if not os.path.isdir(os.path.dirname(save_file)):


### PR DESCRIPTION
Fixes tf.seed not being saved with the network. 